### PR TITLE
Fix coverage action to get proc-macro coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,21 @@ jobs:
           toolchain: stable
           override: true
           components: llvm-tools-preview
-          
+
+      # We need a rustc wrapper that forces -Cinstrument-coverage onto every invocation
+      # to be able to collect code coverage information from proc-macros.
+      - name: Create rustc wrapper
+        run: |
+          echo '#!/bin/bash' > rustc_wrapper
+          echo 'shift;  rustc $@ -Cinstrument-coverage' >> rustc_wrapper
+          chmod +x rustc_wrapper
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
         env:
+          RUSTC_WRAPPER: ${{ github.workspace }}/rustc_wrapper
           RUST_BACKTRACE: 1
           RUSTFLAGS: -Cinstrument-coverage
           
@@ -40,7 +49,7 @@ jobs:
           args: grcov
 
       - name: Generate coverage report
-        run: grcov . -s src --binary-path ./target/debug/ -t lcov --ignore-not-existing -o ./target/debug/coverage.lcov
+        run: grcov ./target/tests/trybuild/variant_partial_eq/ -s src --binary-path ./target/tests/trybuild/debug/deps/ -t lcov --ignore-not-existing -o ./target/debug/coverage.lcov
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
           args: grcov
 
       - name: Generate coverage report
-        run: grcov ./target/tests/trybuild/variant_partial_eq/ -s src --binary-path ./target/tests/trybuild/debug/deps/ -t lcov --ignore-not-existing -o ./target/debug/coverage.lcov
+        run: grcov ./target/tests/trybuild/variant_partial_eq/ -s . --binary-path ./target/tests/trybuild/debug/deps/ -t lcov --ignore-not-existing -o ./target/debug/coverage.lcov --keep-only "src/*"
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
By default, rustc does not pass on rustflags to dependencies. However, since trybuild works by creating a dummy crate that depends on our proc-macro, this means that -Cinstrument-coverage would not get passed down to variant_partial_eq, and thus invocations of our proc-macro (which happen at compile-time since the proc-macro gets loaded dynamically by rustc) will not create .profraw files.

We fix this by using a rustc_wrapper that forces all rustc invocations to get a -Cinstrument-coverage.